### PR TITLE
Fix: Atom doesn't auto identify Vlang src files

### DIFF
--- a/grammars/v.tmLanguage.json
+++ b/grammars/v.tmLanguage.json
@@ -1,7 +1,7 @@
 {
 	"name": "V",
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"fileTypes": [".v", ".vh", ".vsh"],
+	"fileTypes": ["v", "vh", "vsh"],
 	"scopeName": "source.v",
 	"patterns": [
 		{


### PR DESCRIPTION
I know I shouldn't "...suggest improvements or submit corrections here...", but as far as I know, Atom's auto language identify feature won't work if file extensions start with a `.`. This little change solves that annoying "bug"